### PR TITLE
Add process documentation to the "how-to" page

### DIFF
--- a/help/glossary.md
+++ b/help/glossary.md
@@ -38,11 +38,17 @@ A diff is the _difference_ in changes between two commits, or saved changes. The
 
 Fetching refers to getting the latest changes from an online repository without merging them in. Once these changes are fetched you can compare them to your local branches (the files residing on your local machine).
 
-## Ignore (.gitignore)
+## Ignore
 
 Git will look for a special file in the root of your repo called `.gitignore` and ignore any files in the repo that match any of the patterns defined therein. You can read more about git ignore [here](https://git-scm.com/docs/gitignore).
 
-Tip: Because Finder hides files with names starting in a `.`, you may have to edit this file from a terminal.
+Finder hides files with names starting in a `.`, but you can easily edit this file within Kactus ("Repository" > "Repository Settings" > "Ignored Files").
+
+<figure style="text-align: center;">
+  <img style="width: auto;" src="https://user-images.githubusercontent.com/297461/30068977-6853030c-922d-11e7-94d0-01ef77276851.png" alt="Ignored Files">
+  <figcaption>Managing ignored files in Kactus</figcaption>
+</figure>
+
 
 ## Issue
 

--- a/help/glossary.md
+++ b/help/glossary.md
@@ -38,6 +38,12 @@ A diff is the _difference_ in changes between two commits, or saved changes. The
 
 Fetching refers to getting the latest changes from an online repository without merging them in. Once these changes are fetched you can compare them to your local branches (the files residing on your local machine).
 
+## Ignore (.gitignore)
+
+Git will look for a special file in the root of your repo called `.gitignore` and ignore any files in the repo that match any of the patterns defined therein. You can read more about git ignore [here](https://git-scm.com/docs/gitignore).
+
+Tip: Because Finder hides files with names starting in a `.`, you may have to edit this file from a terminal.
+
 ## Issue
 
 Issues are suggested improvements, tasks or questions related to the repository. Issues can be created by anyone (for public repositories), and are moderated by repository collaborators. Each issue contains its own discussion forum, can be labeled and assigned to a user.

--- a/help/how-to.md
+++ b/help/how-to.md
@@ -1,16 +1,39 @@
 # How does it work?
 
-That's a good question. In a seemingly magical fashion, Kactus transforms your sketch file into separate text files. One for each layer.
+That's a good question. Instead of tracking the *actual* sketch files (or *binaries*) in git, Kactus transforms your sketch file into groups of individual text files – one for each layer/page – that are much more suited for `git` to work with. 
 
----
+## Workflow
 
-## Commit
+The basic workflow looks very similar to how many developers use `git`:
+
+1. Clone your repo locally
+2. Make your changes in Sketch
+3. Commit your changes
+4. Push your changes
+
+However, when working with multiple designers, the [git-flow](https://www.atlassian.com/git/tutorials/comparing-workflows#gitflow-workflow) methodology works very well:
+
+1. Clone your repo (if you're just getting started)
+2. Checkout a feature branch (e.g. `feat/background-color`)
+3. Make your changes in Sketch
+4. Commit your changes
+5. Either:
+    - Push your changes to your git server for others to review/merge
+    - Merge your changes into another branch (master) yourself
+
+## Committing Changes
+
+When Kactus is running (with your repository open), it watches your sketch files and re-parses them when a change is detected. This parsed (or exploded) view of your sketch file is what git tracks.
 
 ![commit](https://user-images.githubusercontent.com/3254314/28254880-df5a388e-6a65-11e7-8b73-8de6fe227927.gif)
 
 ---
 
 ## Merging two parallel branches
+
+1. Checkout the branch you want to merge *into*
+2. Select "Merge into Current Branch" from the "Branch" menu
+3. Select the branch that you want to merge *from*
 
 ![merge](https://user-images.githubusercontent.com/3254314/28254882-e28fb8d0-6a65-11e7-86a5-d766d4303959.gif)
 
@@ -19,3 +42,17 @@ That's a good question. In a seemingly magical fashion, Kactus transforms your s
 ## Sharing text styles across multiple sketch files
 
 ![sharetextstyle](https://user-images.githubusercontent.com/3254314/28254883-e5f79a92-6a65-11e7-86cc-3cfdc687a454.gif)
+
+---
+
+## Existing Repos
+
+If your sketch files are already tracked in a git repository, there are few things you need to do to get the most out of Kactus.
+
+1. Open your repo in Kactus to generate the JSON representation of your sketch files
+2. Commit the generated JSON directories
+2. Untrack sketch files. In most cases, this can be done with git by running: `git rm --cached *.sketch`
+3. Tell git to [ignore](/help/glossary/#ignore) sketch files by adding `*.sketch` to your repo's `.gitignore` file (create it if it doesn't exist)
+
+> *Note:* When you create a new repository with Kactus, it is automatically configured to [ignore](/help/glossary/#ignore) sketch files.
+

--- a/package.json
+++ b/package.json
@@ -1,5 +1,25 @@
 {
+  "scripts": {
+    "build": "ugly-build build"
+  },
   "dependencies": {
     "ugly-build": "^0.1.0"
-  }
+  },
+  "name": "kactus-www",
+  "description": "Kactus.io source",
+  "version": "0.2.6",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kactus-io/website.git"
+  },
+  "author": {
+    "name": "Mathieu Dutour",
+    "email": "mathieu@dutour.me",
+    "url": "http://mathieu.dutour.me"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kactus-io/website/issues"
+  },
+  "homepage": "https://github.com/kactus-io/website"
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "build": "ugly-build build"
   },
   "dependencies": {
-    "ugly-build": "^0.1.0"
+    "ugly-build": "^0.1.1"
   },
   "name": "kactus-www",
   "description": "Kactus.io source",


### PR DESCRIPTION
Also expanded `package.json` to include a scripts block (and others).